### PR TITLE
Update divshot-cli dependency to use all 1.x releases.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mocha-jshint": "^0.0.9"
   },
   "dependencies": {
-    "divshot-cli": "~0.15.7",
+    "divshot-cli": "1.x.x",
     "rsvp": "~3.0.9"
   }
 }


### PR DESCRIPTION
Using `1.x.x` as the version for the `divshot-cli` dependency ensures that users can have the most updated version of the cli. There won't be any breaking api changes in any 1.x releases.
