### PR TITLE
Allow usage of Divshot environment variables in production

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,5 +11,11 @@ module.exports = {
 
   blueprintsPath: function() {
     return path.join(__dirname, 'blueprints');
+  },
+
+  contentFor: function(type, config) {
+    if (type === 'body' && config.environment === 'production') {
+      return '<script src="/__/env.js"></script>';
+    }
   }
 }


### PR DESCRIPTION
Divshot [exposes environment variables in the __env.js script](http://docs.divshot.com/guides/environment-variables). We use these variables for keys that change between the staging and production environments. In the beginning we were specifying all of the keys in `environment.js`, but that made it impossible to use the Divshot "promotion" feature because the build would change based on the environment.

This PR appends the `__env.js` script to the body of the document only in the production environment. This allows us to use the same build for both staging and production so that we can simply push to production by promoting from staging.
