### PR TITLE
Set /assets/** to be cached for a long long time

### DIFF
--- a/blueprints/divshot/files/divshot.json
+++ b/blueprints/divshot/files/divshot.json
@@ -5,5 +5,8 @@
     "/tests": "tests/index.html",
     "/tests/**": "tests/index.html",
     "/**": "index.html"
+  },
+  "cache_control": {
+    "/assets/**": 31536000
   }
 }


### PR DESCRIPTION
Since these are fingerprinted, the divshot default of 5 minutes seems silly.